### PR TITLE
feat: add robots-txt page

### DIFF
--- a/packages/nextjs/components/robots-txt/RobotsTxtDisplay.tsx
+++ b/packages/nextjs/components/robots-txt/RobotsTxtDisplay.tsx
@@ -1,0 +1,14 @@
+import { useRobotsContext } from "~~/context/RobotsContext";
+
+export const RobotsTxtDisplay = () => {
+  const { rewrittenRobots } = useRobotsContext();
+  return (
+    <div>
+      <pre className="overflow-auto bg-slate-600 p-4 h-96">
+        <code className="text-zinc-200" lang="language-yaml">
+          {rewrittenRobots}
+        </code>
+      </pre>
+    </div>
+  );
+};

--- a/packages/nextjs/components/robots-txt/RobotsTxtDisplay.tsx
+++ b/packages/nextjs/components/robots-txt/RobotsTxtDisplay.tsx
@@ -5,6 +5,17 @@ import { useRobotsContext } from "~~/context/RobotsContext";
 export const RobotsTxtDisplay = () => {
   const { rewrittenRobots } = useRobotsContext();
 
+  const exportRobotsTxt = () => {
+    const fileData = rewrittenRobots ?? "";
+    const blob = new Blob([fileData], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.download = "robots.txt";
+    link.href = url;
+    link.click();
+    toast.success("Successfully downloaded robots.txt");
+  };
+
   return !!rewrittenRobots ? (
     <div>
       <pre className="overflow-auto bg-slate-600 p-4 h-96">
@@ -12,12 +23,18 @@ export const RobotsTxtDisplay = () => {
           {rewrittenRobots}
         </code>
       </pre>
-      <div className="mt-16">
+      <div className="mt-16 flex flex-row justify-evenly">
         <CopyToClipboard text={rewrittenRobots} onCopy={() => toast.success("Successfully copied")}>
           <button className="btn btn-primary w-48 rounded-full capitalize font-normal font-white flex items-center gap-1 hover:gap-2 transition-all tracking-widest">
             Copy to clipboard
           </button>
         </CopyToClipboard>
+        <button
+          className="btn btn-primary w-48 rounded-full capitalize font-normal font-white flex items-center gap-1 hover:gap-2 transition-all tracking-widest"
+          onClick={exportRobotsTxt}
+        >
+          Download file
+        </button>
       </div>
     </div>
   ) : (

--- a/packages/nextjs/components/robots-txt/RobotsTxtDisplay.tsx
+++ b/packages/nextjs/components/robots-txt/RobotsTxtDisplay.tsx
@@ -1,14 +1,26 @@
+import { CopyToClipboard } from "react-copy-to-clipboard";
+import toast from "react-hot-toast";
 import { useRobotsContext } from "~~/context/RobotsContext";
 
 export const RobotsTxtDisplay = () => {
   const { rewrittenRobots } = useRobotsContext();
-  return (
+
+  return !!rewrittenRobots ? (
     <div>
       <pre className="overflow-auto bg-slate-600 p-4 h-96">
         <code className="text-zinc-200" lang="language-yaml">
           {rewrittenRobots}
         </code>
       </pre>
+      <div className="mt-16">
+        <CopyToClipboard text={rewrittenRobots} onCopy={() => toast.success("Successfully copied")}>
+          <button className="btn btn-primary w-48 rounded-full capitalize font-normal font-white flex items-center gap-1 hover:gap-2 transition-all tracking-widest">
+            Copy to clipboard
+          </button>
+        </CopyToClipboard>
+      </div>
     </div>
+  ) : (
+    <></>
   );
 };

--- a/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
+++ b/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
@@ -7,13 +7,13 @@ export const UserAgentCheckList = () => {
   const { parsedRobotsTxt } = useRobotsContext();
   const [isLoading, setIsLoading] = useState(true);
   const [userAgents, setUserAgents] = useState<string[]>([]);
-  const [newRobots, setNewRobots] = useState<Record<string, boolean>>(
+  const [userAgentBlockSelection, setUserAgentBlockSelection] = useState<Record<string, boolean>>(
     recommendedAgentsToBlock.reduce((acc, agent) => ({ ...acc, [agent]: true }), {}),
   );
 
   const toggleAgent = (agent: string) => {
     if (userAgents.includes(agent)) {
-      setNewRobots(prevState => ({ ...prevState, [agent]: !prevState?.[agent] }));
+      setUserAgentBlockSelection(prevState => ({ ...prevState, [agent]: !prevState?.[agent] }));
     }
   };
 
@@ -23,11 +23,11 @@ export const UserAgentCheckList = () => {
       setUserAgents(
         Object.keys({
           ...parsedRobotsTxt,
-          ...newRobots,
+          ...userAgentBlockSelection,
         }),
       );
     }
-  }, [newRobots, parsedRobotsTxt, userAgents.length]);
+  }, [userAgentBlockSelection, parsedRobotsTxt, userAgents.length]);
 
   useEffect(() => {
     if (parsedRobotsTxt && userAgents) {
@@ -39,7 +39,7 @@ export const UserAgentCheckList = () => {
         }),
         {},
       );
-      setNewRobots(simplifiedObj);
+      setUserAgentBlockSelection(simplifiedObj);
       setIsLoading(false);
     }
   }, [parsedRobotsTxt, userAgents]);
@@ -49,13 +49,16 @@ export const UserAgentCheckList = () => {
       <ul>
         {userAgents.map((agent, idx) => (
           <li key={`${agent}-${idx}`} className="flex flex-row gap-4" onClick={() => toggleAgent(agent)}>
-            <input type="checkbox" value={agent} checked={newRobots[agent]} />
+            <input type="checkbox" value={agent} checked={userAgentBlockSelection[agent]} />
             <p>
               {recommendedAgentsToBlock.includes(agent) && "[Recommended]"} {agent}
             </p>
           </li>
         ))}
       </ul>
+      <button className="btn btn-primary w-60 rounded-full capitalize font-normal font-white flex items-center gap-1 hover:gap-2 transition-all tracking-widest">
+        Generate new robots file
+      </button>
     </div>
   ) : (
     <span className="loading loading-spinner loading-sm" />

--- a/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
+++ b/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
@@ -1,17 +1,46 @@
+import { useEffect, useState } from "react";
 import { useRobotsContext } from "~~/context/RobotsContext";
 
 export const UserAgentCheckList = () => {
   const { parsedRobotsTxt } = useRobotsContext();
-  const userAgents = parsedRobotsTxt ? Object.keys(parsedRobotsTxt) : [];
-  return (
-    parsedRobotsTxt && (
+  const [userAgents, setUserAgents] = useState<string[]>([]);
+  const [newRobots, setNewRobots] = useState<Record<string, boolean>>();
+
+  const toggleAgent = (agent: string) => {
+    if (userAgents.includes(agent)) {
+      setNewRobots(prevState => ({ ...prevState, [agent]: !prevState?.[agent] }));
+    }
+  };
+
+  useEffect(() => {
+    if (parsedRobotsTxt) {
+      setUserAgents(Object.keys(parsedRobotsTxt));
+    }
+  }, [parsedRobotsTxt]);
+
+  useEffect(() => {
+    if (parsedRobotsTxt && userAgents) {
+      const simplifiedObj = userAgents.reduce(
+        (acc, agent) => ({
+          ...acc,
+          [agent]: !parsedRobotsTxt[agent].generallyAllowed,
+        }),
+        {},
+      );
+      setNewRobots(simplifiedObj);
+    }
+  }, [parsedRobotsTxt, userAgents]);
+
+  return newRobots ? (
+    <div>
       <ul>
         {userAgents.map((agent, idx) => (
-          <li key={agent + idx}>
-            {agent} is {parsedRobotsTxt[agent].generallyAllowed ? "" : "not "}allowed
+          <li key={`${agent}-${idx}`} className="flex flex-row gap-4" onClick={() => toggleAgent(agent)}>
+            <input type="checkbox" value={agent} checked={newRobots[agent]} />
+            <p>{agent}</p>
           </li>
         ))}
       </ul>
-    )
-  );
+    </div>
+  ) : undefined;
 };

--- a/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
+++ b/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
@@ -4,8 +4,9 @@ import { useRobotsContext } from "~~/context/RobotsContext";
 const recommendedAgentsToBlock = ["GPTBot", "CCBot"];
 
 export const UserAgentCheckList = () => {
-  const { parsedRobotsTxt, generateNewRobots } = useRobotsContext();
+  const { parsedRobotsTxt, generateNewRobots, rewrittenRobots } = useRobotsContext();
   const [isLoading, setIsLoading] = useState(true);
+  const [showNewFile, setShowNewFile] = useState(false);
   const [userAgents, setUserAgents] = useState<string[]>([]);
   const [userAgentBlockSelection, setUserAgentBlockSelection] = useState<Record<string, boolean>>(
     recommendedAgentsToBlock.reduce((acc, agent) => ({ ...acc, [agent]: true }), {}),
@@ -18,6 +19,7 @@ export const UserAgentCheckList = () => {
   };
 
   const handleGenerateRobots = () => {
+    setIsLoading(true);
     generateNewRobots(userAgentBlockSelection);
   };
 
@@ -48,7 +50,24 @@ export const UserAgentCheckList = () => {
     }
   }, [parsedRobotsTxt, userAgents]);
 
-  return !isLoading ? (
+  useEffect(() => {
+    if (!!rewrittenRobots && isLoading && !showNewFile) {
+      setShowNewFile(true);
+      setIsLoading(false);
+    }
+  }, [isLoading, rewrittenRobots, showNewFile]);
+
+  return isLoading ? (
+    <span className="loading loading-spinner loading-sm" />
+  ) : showNewFile ? (
+    <div>
+      <pre className="overflow-auto bg-slate-600 p-4">
+        <code className="text-zinc-200" lang="language-markdown">
+          {rewrittenRobots}
+        </code>
+      </pre>
+    </div>
+  ) : (
     <div>
       <ul>
         {userAgents.map((agent, idx) => (
@@ -67,7 +86,5 @@ export const UserAgentCheckList = () => {
         Generate new robots file
       </button>
     </div>
-  ) : (
-    <span className="loading loading-spinner loading-sm" />
   );
 };

--- a/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
+++ b/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
@@ -4,7 +4,7 @@ import { useRobotsContext } from "~~/context/RobotsContext";
 const recommendedAgentsToBlock = ["GPTBot", "CCBot"];
 
 export const UserAgentCheckList = () => {
-  const { parsedRobotsTxt } = useRobotsContext();
+  const { parsedRobotsTxt, generateNewRobots } = useRobotsContext();
   const [isLoading, setIsLoading] = useState(true);
   const [userAgents, setUserAgents] = useState<string[]>([]);
   const [userAgentBlockSelection, setUserAgentBlockSelection] = useState<Record<string, boolean>>(
@@ -15,6 +15,10 @@ export const UserAgentCheckList = () => {
     if (userAgents.includes(agent)) {
       setUserAgentBlockSelection(prevState => ({ ...prevState, [agent]: !prevState?.[agent] }));
     }
+  };
+
+  const handleGenerateRobots = () => {
+    generateNewRobots(userAgentBlockSelection);
   };
 
   useEffect(() => {
@@ -56,7 +60,10 @@ export const UserAgentCheckList = () => {
           </li>
         ))}
       </ul>
-      <button className="btn btn-primary w-60 rounded-full capitalize font-normal font-white flex items-center gap-1 hover:gap-2 transition-all tracking-widest">
+      <button
+        className="btn btn-primary w-60 rounded-full capitalize font-normal font-white flex items-center gap-1 hover:gap-2 transition-all tracking-widest"
+        onClick={handleGenerateRobots}
+      >
         Generate new robots file
       </button>
     </div>

--- a/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
+++ b/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
@@ -5,6 +5,7 @@ const recommendedAgentsToBlock = ["GPTBot", "CCBot"];
 
 export const UserAgentCheckList = () => {
   const { parsedRobotsTxt } = useRobotsContext();
+  const [isLoading, setIsLoading] = useState(true);
   const [userAgents, setUserAgents] = useState<string[]>([]);
   const [newRobots, setNewRobots] = useState<Record<string, boolean>>(
     recommendedAgentsToBlock.reduce((acc, agent) => ({ ...acc, [agent]: true }), {}),
@@ -39,10 +40,11 @@ export const UserAgentCheckList = () => {
         {},
       );
       setNewRobots(simplifiedObj);
+      setIsLoading(false);
     }
   }, [parsedRobotsTxt, userAgents]);
 
-  return newRobots && parsedRobotsTxt && userAgents ? (
+  return !isLoading ? (
     <div>
       <ul>
         {userAgents.map((agent, idx) => (
@@ -55,5 +57,7 @@ export const UserAgentCheckList = () => {
         ))}
       </ul>
     </div>
-  ) : undefined;
+  ) : (
+    <span className="loading loading-spinner loading-sm" />
+  );
 };

--- a/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
+++ b/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
@@ -1,0 +1,17 @@
+import { useRobotsContext } from "~~/context/RobotsContext";
+
+export const UserAgentCheckList = () => {
+  const { parsedRobotsTxt } = useRobotsContext();
+  const userAgents = parsedRobotsTxt ? Object.keys(parsedRobotsTxt) : [];
+  return (
+    parsedRobotsTxt && (
+      <ul>
+        {userAgents.map((agent, idx) => (
+          <li key={agent + idx}>
+            {agent} is {parsedRobotsTxt[agent].generallyAllowed ? "" : "not "}allowed
+          </li>
+        ))}
+      </ul>
+    )
+  );
+};

--- a/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
+++ b/packages/nextjs/components/robots-txt/UserAgentCheckList.tsx
@@ -59,14 +59,6 @@ export const UserAgentCheckList = () => {
 
   return isLoading ? (
     <span className="loading loading-spinner loading-sm" />
-  ) : showNewFile ? (
-    <div>
-      <pre className="overflow-auto bg-slate-600 p-4">
-        <code className="text-zinc-200" lang="language-markdown">
-          {rewrittenRobots}
-        </code>
-      </pre>
-    </div>
   ) : (
     <div>
       <ul>

--- a/packages/nextjs/context/RobotsContext.tsx
+++ b/packages/nextjs/context/RobotsContext.tsx
@@ -2,6 +2,7 @@ import { PropsWithChildren, useEffect, useState } from "react";
 import { createCtx } from ".";
 import axios from "axios";
 import { parseRobots } from "~~/utils/robots/parseRobots";
+import { writeNewRobots } from "~~/utils/robots/writeNewRobots";
 
 // NGROK tunneling
 const EXPRESS_URL = "https://correctly-leading-chicken.ngrok-free.app";
@@ -10,6 +11,7 @@ const EXPRESS_URL = "https://correctly-leading-chicken.ngrok-free.app";
 type RobotsContextState = {
   originalRobotsTxt?: string;
   parsedRobotsTxt?: Record<string, { allow: string[]; disallow: string[]; generallyAllowed: boolean }>;
+  rewrittenRobots?: string;
 };
 
 // This interface differentiates from State
@@ -17,6 +19,7 @@ type RobotsContextState = {
 // that handle the state in some way
 interface RobotsContext extends RobotsContextState {
   getRobotsTxt: (url: string) => Promise<void>;
+  generateNewRobots: (userAgentBlockSelection: Record<string, boolean>) => void;
 }
 
 const [useContext, RobotsContextProvider] = createCtx<RobotsContext>("web3Context");
@@ -56,7 +59,17 @@ export const RobotsProvider = ({ children }: PropsWithChildren) => {
     }
   };
 
-  return <RobotsContextProvider value={{ ...state, getRobotsTxt }}>{children}</RobotsContextProvider>;
+  const generateNewRobots = (userAgentBlockSelection: Record<string, boolean>) => {
+    if (state?.originalRobotsTxt) {
+      const rewrittenRobots = writeNewRobots(state?.originalRobotsTxt, userAgentBlockSelection);
+      setState(prevState => ({ ...prevState, rewrittenRobots }));
+    }
+    return;
+  };
+
+  return (
+    <RobotsContextProvider value={{ ...state, getRobotsTxt, generateNewRobots }}>{children}</RobotsContextProvider>
+  );
 };
 
 export const useRobotsContext = useContext;

--- a/packages/nextjs/context/RobotsContext.tsx
+++ b/packages/nextjs/context/RobotsContext.tsx
@@ -1,6 +1,7 @@
-import { PropsWithChildren, useState } from "react";
+import { PropsWithChildren, useEffect, useState } from "react";
 import { createCtx } from ".";
 import axios from "axios";
+import { parseRobots } from "~~/utils/robots/parseRobots";
 
 // NGROK tunneling
 const EXPRESS_URL = "https://correctly-leading-chicken.ngrok-free.app";
@@ -22,6 +23,13 @@ const [useContext, RobotsContextProvider] = createCtx<RobotsContext>("web3Contex
 
 export const RobotsProvider = ({ children }: PropsWithChildren) => {
   const [state, setState] = useState<RobotsContextState>();
+
+  useEffect(() => {
+    if (!!state?.originalRobotsTxt) {
+      const parsedRobotsTxt = parseRobots(state.originalRobotsTxt);
+      setState(prevState => ({ ...prevState, parsedRobotsTxt }));
+    }
+  }, [state?.originalRobotsTxt]);
 
   const getRobotsTxt = async (url: string) => {
     try {

--- a/packages/nextjs/context/RobotsContext.tsx
+++ b/packages/nextjs/context/RobotsContext.tsx
@@ -8,6 +8,7 @@ const EXPRESS_URL = "https://correctly-leading-chicken.ngrok-free.app";
 // State variables only
 type RobotsContextState = {
   originalRobotsTxt?: string;
+  parsedRobotsTxt?: Record<string, { allow: string[]; disallow: string[]; generallyAllowed: boolean }>;
 };
 
 // This interface differentiates from State

--- a/packages/nextjs/pages/protect/index.tsx
+++ b/packages/nextjs/pages/protect/index.tsx
@@ -1,0 +1,10 @@
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function Protect() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace("/protect/landing");
+  }, [router]);
+  return <></>;
+}

--- a/packages/nextjs/pages/protect/robots-txt.tsx
+++ b/packages/nextjs/pages/protect/robots-txt.tsx
@@ -1,13 +1,14 @@
 import { useRouter } from "next/router";
+import { UserAgentCheckList } from "~~/components/robots-txt/UserAgentCheckList";
 import { useRobotsContext } from "~~/context/RobotsContext";
 
 export const RobotsTxt = () => {
   const router = useRouter();
-  const { originalRobotsTxt } = useRobotsContext();
+  const { parsedRobotsTxt } = useRobotsContext();
 
   const redirectToLanding = () => router.replace("/protect/landing");
 
-  if (!originalRobotsTxt) {
+  if (!parsedRobotsTxt) {
     return (
       <div className="p-32 flex-grow" data-theme="exampleUi">
         <h1 className="text-4xl sm:text-6xl mb-32">Please go to the previous page to initiate the protect process</h1>
@@ -23,7 +24,11 @@ export const RobotsTxt = () => {
 
   return (
     <div className="p-32 flex-grow" data-theme="exampleUi">
-      <h1 className="text-4xl sm:text-6xl">On this page the CC user would analyze the robots.txt</h1>
+      <h1 className="text-4xl sm:text-6xl">Analyze your robots.txt</h1>
+      <h3 className="text-xl sm:text-2xl">
+        Please review the list of agents below and determine toggle their access permissions
+      </h3>
+      <UserAgentCheckList />
     </div>
   );
 };

--- a/packages/nextjs/pages/protect/robots-txt.tsx
+++ b/packages/nextjs/pages/protect/robots-txt.tsx
@@ -1,10 +1,11 @@
 import { useRouter } from "next/router";
+import { RobotsTxtDisplay } from "~~/components/robots-txt/RobotsTxtDisplay";
 import { UserAgentCheckList } from "~~/components/robots-txt/UserAgentCheckList";
 import { useRobotsContext } from "~~/context/RobotsContext";
 
 export const RobotsTxt = () => {
   const router = useRouter();
-  const { parsedRobotsTxt } = useRobotsContext();
+  const { parsedRobotsTxt, rewrittenRobots } = useRobotsContext();
 
   const redirectToLanding = () => router.replace("/protect/landing");
 
@@ -24,9 +25,13 @@ export const RobotsTxt = () => {
 
   return (
     <div className="p-32 flex-grow" data-theme="exampleUi">
-      <h1 className="text-4xl sm:text-6xl">Analyze your robots.txt</h1>
-      <h3 className="text-xl sm:text-2xl">Select which user agents you want to block from your site</h3>
-      <UserAgentCheckList />
+      <h1 className="text-4xl sm:text-6xl">{!!rewrittenRobots ? "New robots.txt file" : "Analyze your robots.txt"}</h1>
+      <h3 className="text-xl sm:text-2xl">
+        {!!rewrittenRobots
+          ? "Copy the new file and use it on your site"
+          : "Select which user agents you want to block from your site"}
+      </h3>
+      {!!rewrittenRobots ? <RobotsTxtDisplay /> : <UserAgentCheckList />}
     </div>
   );
 };

--- a/packages/nextjs/pages/protect/robots-txt.tsx
+++ b/packages/nextjs/pages/protect/robots-txt.tsx
@@ -25,9 +25,7 @@ export const RobotsTxt = () => {
   return (
     <div className="p-32 flex-grow" data-theme="exampleUi">
       <h1 className="text-4xl sm:text-6xl">Analyze your robots.txt</h1>
-      <h3 className="text-xl sm:text-2xl">
-        Please review the list of agents below and determine toggle their access permissions
-      </h3>
+      <h3 className="text-xl sm:text-2xl">Select which user agents you want to block from your site</h3>
       <UserAgentCheckList />
     </div>
   );

--- a/packages/nextjs/pages/protect/robots-txt.tsx
+++ b/packages/nextjs/pages/protect/robots-txt.tsx
@@ -1,4 +1,26 @@
-export const RobotsTxt = ({}) => {
+import { useRouter } from "next/router";
+import { useRobotsContext } from "~~/context/RobotsContext";
+
+export const RobotsTxt = () => {
+  const router = useRouter();
+  const { originalRobotsTxt } = useRobotsContext();
+
+  const redirectToLanding = () => router.replace("/protect/landing");
+
+  if (!originalRobotsTxt) {
+    return (
+      <div className="p-32 flex-grow" data-theme="exampleUi">
+        <h1 className="text-4xl sm:text-6xl mb-32">Please go to the previous page to initiate the protect process</h1>
+        <button
+          className="btn btn-primary w-32 rounded-full capitalize font-normal font-white flex items-center gap-1 hover:gap-2 transition-all tracking-widest"
+          onClick={redirectToLanding}
+        >
+          Click here
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="p-32 flex-grow" data-theme="exampleUi">
       <h1 className="text-4xl sm:text-6xl">On this page the CC user would analyze the robots.txt</h1>

--- a/packages/nextjs/utils/robots/parseRobots.ts
+++ b/packages/nextjs/utils/robots/parseRobots.ts
@@ -1,0 +1,29 @@
+// @TODO: add testing
+export const parseRobots = (s: string) => {
+  const result: Record<string, { allow: string[]; disallow: string[]; generallyAllowed: boolean }> = {};
+
+  const lines = s.split("\n");
+  let currentAgent = "";
+
+  lines.forEach(line => {
+    if (line.includes("User-agent: ")) {
+      currentAgent = line.split("User-agent: ")[1];
+      result[currentAgent] = { allow: [], disallow: [], generallyAllowed: true };
+      return;
+    }
+    if (line.includes("Allow: ")) {
+      const allowedPath = line.split("Allow: ")[1];
+      result[currentAgent]["allow"].push(allowedPath);
+      return;
+    }
+    if (line.includes("Disallow: ")) {
+      const disallowedPath = line.split("Disallow: ")[1];
+      if (disallowedPath === "/") {
+        result[currentAgent]["generallyAllowed"] = false;
+      }
+      result[currentAgent]["disallow"].push(disallowedPath);
+      return;
+    }
+  });
+  return result;
+};

--- a/packages/nextjs/utils/robots/writeNewRobots.ts
+++ b/packages/nextjs/utils/robots/writeNewRobots.ts
@@ -1,0 +1,52 @@
+export const writeNewRobots = (original: string, newConfig: Record<string, boolean>) => {
+  const lines = original.split("\n");
+  let currentAgent = "";
+  const savedAgents: string[] = [];
+  const agentsList = Object.keys(newConfig);
+
+  // Overwrite original's config lines with new config
+  const newLines = lines.map(line => {
+    // break if no further changes are needed
+    if (agentsList.length === savedAgents.length) {
+      return line;
+    }
+    // get current agent
+    if (line.includes("User-agent")) {
+      currentAgent = line.split("User-agent: ")[1];
+      return line;
+    }
+    // process path allow directive
+    if (line.includes("Allow")) {
+      const allowedPath = line.split("Allow: ")[1];
+      const idx = agentsList.indexOf(currentAgent);
+      // Check if the directive needs to be changed
+      if (allowedPath === "/" && idx >= 0) {
+        const shouldBlock = newConfig[agentsList[idx]];
+        savedAgents.push(agentsList[idx]);
+        if (shouldBlock) {
+          return "Disallow: " + allowedPath;
+        }
+      }
+      return line;
+    }
+    // process path disallow directive
+    if (line.includes("Disallow")) {
+      const disallowedPath = line.split("Disallow: ")[1];
+      const idx = agentsList.indexOf(currentAgent);
+      // Check if the directive needs to be changed
+      if (disallowedPath === "/" && idx >= 0) {
+        const shouldAllow = !newConfig[agentsList[idx]];
+        savedAgents.push(agentsList[idx]);
+        if (shouldAllow) {
+          return "Allow: " + disallowedPath;
+        }
+      }
+      return line;
+    }
+    return line;
+  });
+
+  // @TODO: add missing user-agents
+
+  return newLines;
+};

--- a/packages/nextjs/utils/robots/writeNewRobots.ts
+++ b/packages/nextjs/utils/robots/writeNewRobots.ts
@@ -1,3 +1,19 @@
+const PREFACE =
+  "\n\n# This file was modified by BotBlock's protection tool\n# The next section adds missing user-agents.\n\n";
+
+const appendRemainingAgents = (agents: string[], config: Record<string, boolean>) => {
+  return (
+    PREFACE +
+    agents
+      .map(item => {
+        const agentsLine = "User-agent: " + item + "\n";
+        const directiveLine = (config[item] ? "Disallow: " : "Allow: ") + "/" + "\n";
+        return agentsLine + directiveLine;
+      })
+      .join("\n")
+  );
+};
+
 export const writeNewRobots = (original: string, newConfig: Record<string, boolean>) => {
   const lines = original.split("\n");
   let currentAgent = "";
@@ -46,7 +62,7 @@ export const writeNewRobots = (original: string, newConfig: Record<string, boole
     return line;
   });
 
-  // @TODO: add missing user-agents
+  const remainingAgents = agentsList.filter(agent => !savedAgents.includes(agent));
 
-  return newLines;
+  return newLines.join("\n") + appendRemainingAgents(remainingAgents, newConfig);
 };


### PR DESCRIPTION
## Description

After fetching and selecting which agents to allow or block, we generate new robots file with the new spec.

Improvements can certainly be made here, for example not adding the allow statement. Since we time-boxed this feature to be shorter to deliver the product faster, we left it for follow-up PRs.

Another improvement could be to reset page's state when browsing back and forth to avoid any weird interactions.

# How to test

1. Start express server by running `yarn start` on `./packages/express`
3. Start nextjs by running `yarn dev` on `./packages/nextjs`
4. Browse to `protect/landing`
5. Enter some valid url to fetch its `robots.txt` from (i.e. `https://www.google.com`)
6. Click submit
7. Select agents to block
8. Submit to generate new robots.txt file
9. Check that the new robots.txt complies with the requirements
10. Check that the copy to clipboard and download buttons work

## Related links

- Closes #3

## Proof

| _Demo_ |
| :---: |
| <video src='https://github.com/fabriziogianni7/botblock/assets/21087992/e471d67b-c198-4fe0-beac-747e9c9c4f53' > |